### PR TITLE
Mapgen rework, copper pickaxe, swamp veins

### DIFF
--- a/Mining_Mod/items.json
+++ b/Mining_Mod/items.json
@@ -94,5 +94,23 @@
     "weight" : 2400,
     "bashing" : 2,
     "ammo_type" : "components"
+  },
+  {
+    "id": "pickaxe_copper",
+    "type": "TOOL",
+    "name": "copper pickaxe",
+    "description": "This is a handmade copper pickaxe, suitable for breaking up hard things or (with enough skill) hard targets.  Strike the earth!",
+    "sub": "pickaxe",
+    "weight": 6350,
+    "volume": 12,
+    "price": 1600,
+    "to_hit": -3,
+    "bashing": 12,
+    "cutting": 4,
+    "material": [ "wood", "copper" ],
+    "symbol": "/",
+    "color": "light_red",
+    "use_action": "PICKAXE",
+    "flags": [ "SPEAR", "NONCONDUCTIVE" ]
   }
 ]

--- a/Mining_Mod/mapgen_shallow.json
+++ b/Mining_Mod/mapgen_shallow.json
@@ -388,5 +388,44 @@
     "?": [ "t_rock", "t_rock_hematite" ]
    }
   }
+},
+{
+  "type" : "mapgen",
+  "om_terrain" : ["vein_hematite"],
+  "method": "json",
+  "weight": 400, "comment": "Hematite vein, set aside for bog iron.  Realistically should be limonite.",
+  "object": {
+   "rows": [
+    "                        ",
+    "                        ",
+    "                        ",
+    "                        ",
+    "                        ",
+    "                        ",
+    "                        ",
+    "       ??               ",
+    "        ???             ",
+    "        ?##?            ",
+    "         ?##?           ",
+    "          ?##?          ",
+    "           ?##?         ",
+    "            ???         ",
+    "               ?        ",
+    "                        ",
+    "                        ",
+    "                        ",
+    "                        ",
+    "                        ",
+    "                        ",
+    "                        ",
+    "                        ",
+    "                        "
+            ],
+   "terrain": {
+    " ": "t_rock",
+    "#": "t_rock_hematite",
+    "?": [ "t_rock", "t_rock_hematite" ]
+   }
+  }
 }
 ]

--- a/Mining_Mod/mapgen_surface.json
+++ b/Mining_Mod/mapgen_surface.json
@@ -1,4 +1,12 @@
 [
+  {
+    "id": "minerals_swamp",
+    "type": "item_group",
+    "comment": "Technically limonite develops as bog iron, not hematite.",
+    "items": [
+      [ "chunk_hematite", 10 ]
+    ]
+  },
 {
   "type" : "mapgen",
   "om_terrain" : ["field_shallow"],
@@ -326,12 +334,12 @@
     "                        "
             ],
    "terrain": {
-    " ": [ "t_tree_dead","t_tree_dead","t_tree_dead","t_grass","t_grass","t_grass","t_grass","t_grass",
-          "t_tree_young","t_tree_young","t_grass","t_grass","t_tree_dead","t_tree_dead","t_dirt","t_dirt","t_dirt",
+    " ": [ "t_tree_dead","t_tree_dead","t_grass","t_grass","t_grass","t_grass","t_grass",
+          "t_tree_young","t_grass","t_grass","t_tree_dead","t_tree_dead","t_dirt","t_dirt","t_dirt",
           "t_tree_deadpine","t_tree_deadpine","t_tree_deadpine","t_grass","t_dirt","t_dirt","t_dirt","t_dirt","t_dirt",
           "t_tree_young","t_tree_young","t_grass","t_grass","t_tree_deadpine","t_tree_deadpine","t_dirt","t_dirt","t_dirt",
-          "t_tree","t_tree","t_grass","t_grass","t_tree","t_dirt","t_dirt","t_dirt","t_underbrush",
-          "t_tree_pine","t_tree_pine","t_grass","t_grass","t_tree_pine","t_tree_pine","t_dirt","t_dirt","t_dirt",
+          "t_tree","t_grass","t_grass","t_tree","t_dirt","t_dirt","t_dirt","t_underbrush",
+          "t_tree_pine","t_grass","t_grass","t_tree_pine","t_tree_pine","t_dirt","t_dirt","t_dirt",
           "t_dirt","t_underbrush","t_underbrush"],
     "#": "t_rock_floor",
     ".": "t_dirt",
@@ -376,12 +384,12 @@
     "                        "
             ],
    "terrain": {
-    " ": [ "t_tree_dead","t_tree_dead","t_tree_dead","t_grass","t_grass","t_grass","t_grass","t_grass",
-          "t_tree_young","t_tree_young","t_grass","t_grass","t_tree_dead","t_tree_dead","t_dirt","t_dirt","t_dirt",
-          "t_tree_deadpine","t_tree_deadpine","t_tree_deadpine","t_grass","t_dirt","t_dirt","t_dirt","t_dirt","t_dirt",
-          "t_tree_young","t_tree_young","t_grass","t_grass","t_tree_deadpine","t_tree_deadpine","t_dirt","t_dirt","t_dirt",
-          "t_tree","t_tree","t_grass","t_grass","t_tree","t_dirt","t_dirt","t_dirt","t_underbrush",
-          "t_tree_pine","t_tree_pine","t_grass","t_grass","t_tree_pine","t_tree_pine","t_dirt","t_dirt","t_dirt",
+    " ": [ "t_tree_dead","t_tree_dead","t_grass","t_grass","t_grass","t_grass","t_grass",
+          "t_tree_young","t_grass","t_grass","t_tree_dead","t_tree_dead","t_dirt","t_dirt","t_dirt",
+          "t_tree_deadpine","t_tree_deadpine","t_grass","t_dirt","t_dirt","t_dirt","t_dirt","t_dirt",
+          "t_tree_young","t_grass","t_grass","t_tree_deadpine","t_dirt","t_dirt","t_dirt",
+          "t_tree","t_grass","t_grass","t_tree","t_dirt","t_dirt","t_dirt","t_underbrush",
+          "t_tree_pine","t_grass","t_grass","t_dirt","t_dirt","t_dirt",
           "t_dirt","t_underbrush","t_underbrush"],
         "%": "t_dirt"
    },
@@ -389,5 +397,107 @@
         "%": [ "f_null", "f_rubble_rock" ]
       }
 }
+},
+{
+  "type" : "mapgen",
+  "om_terrain" : ["swamp_vein"],
+  "method": "json",
+  "weight": 1000, "comment": "Suspisciously dry, dead patch of ground, with small hints of fragmenta.",
+  "object": {
+   "rows": [
+    "                        ",
+    "                        ",
+    "                        ",
+    "                        ",
+    "                        ",
+    "                        ",
+    "             .          ",
+    "        ..  .%.         ",
+    "        .%......        ",
+    "         ....%..        ",
+    "       ...%...%..       ",
+    "       .%...%...%.      ",
+    "        ...%%%....      ",
+    "     ..  ...%....%.     ",
+    "    .%....%....%..      ",
+    "     ....%....%..       ",
+    "      .%... .%.%.       ",
+    "      ...    ...        ",
+    "                        ",
+    "                        ",
+    "                        ",
+    "                        ",
+    "                        ",
+    "                        "
+            ],
+   "terrain": {
+    " ": [ "t_water_sh","t_water_dp","t_grass","t_grass","t_grass","t_grass","t_grass","t_grass",
+          "t_swater_sh","t_swater_sh","t_swater_dp","t_grass","t_dirt","t_dirt","t_dirt","t_dirt","t_dirt",
+          "t_swater_sh","t_swater_dp","t_swater_sh","t_grass","t_dirt","t_dirt","t_dirt","t_dirt","t_dirt",
+          "t_grass","t_grass","t_grass","t_grass","t_dirt","t_dirt","t_dirt","t_dirt","t_dirt",
+          "t_grass","t_grass","t_grass","t_grass","t_dirt","t_dirt","t_dirt","t_dirt","t_dirt",
+          "t_grass","t_grass","t_grass","t_grass","t_dirt","t_dirt","t_dirt","t_dirt","t_dirt",
+          "t_dirt","t_dirt","t_underbrush"],
+        ".": "t_dirt",
+        "%": "t_dirt"
+   },
+      "furniture": {
+        " ": [ "f_null", "f_null", "f_null", "f_null", "f_null", "f_null", "f_null", "f_null", "f_null", "f_null", "f_null", "f_null", "f_null", "f_null", "f_null", "f_null", "f_null", "f_null", "f_null", "f_null", "f_null", "f_null", "f_null", "f_null", "f_null", "f_null", "f_null", "f_null", "f_rubble_rock", "f_cattails" ],
+        "%": [ "f_null", "f_rubble_rock" ]
+      }
+	}
+},
+{
+  "type" : "mapgen",
+  "om_terrain" : ["swamp_hematite"],
+  "method": "json",
+  "weight": 1000, "comment": "Suspisciously dry, dead patch of ground, with small hints of fragmenta.  Some chance of bog iron.",
+  "object": {
+   "rows": [
+    "                        ",
+    "                        ",
+    "        .               ",
+    "       .%.              ",
+    "      ...               ",
+    "     .%.                ",
+    "      ...               ",
+    "      .....             ",
+    "        .%.....         ",
+    "       .%..%.%..        ",
+    "       ...%...%..       ",
+    "       .%...%...        ",
+    "        ...%%%...       ",
+    "        ....%....       ",
+    "       ...%....%.       ",
+    "        .%....%..       ",
+    "         .. .%.%.       ",
+    "            ......      ",
+    "             ....%.     ",
+    "             .%....     ",
+    "              ...%.     ",
+    "                ..      ",
+    "                        ",
+    "                        "
+            ],
+   "terrain": {
+    " ": [ "t_water_sh","t_water_dp","t_grass","t_grass","t_grass","t_grass","t_grass","t_grass",
+          "t_swater_sh","t_swater_sh","t_swater_dp","t_grass","t_dirt","t_dirt","t_dirt","t_dirt","t_dirt",
+          "t_swater_sh","t_swater_dp","t_swater_sh","t_grass","t_dirt","t_dirt","t_dirt","t_dirt","t_dirt",
+          "t_grass","t_grass","t_grass","t_grass","t_dirt","t_dirt","t_dirt","t_dirt","t_dirt",
+          "t_grass","t_grass","t_grass","t_grass","t_dirt","t_dirt","t_dirt","t_dirt","t_dirt",
+          "t_grass","t_grass","t_grass","t_grass","t_dirt","t_dirt","t_dirt","t_dirt","t_dirt",
+          "t_dirt","t_dirt","t_underbrush"],
+        ".": "t_dirt",
+        "%": "t_dirt"
+   },
+      "furniture": {
+        " ": [ "f_null", "f_null", "f_null", "f_null", "f_null", "f_null", "f_null", "f_null", "f_null", "f_null", "f_null", "f_null", "f_null", "f_null", "f_null", "f_null", "f_null", "f_null", "f_null", "f_null", "f_null", "f_null", "f_null", "f_null", "f_null", "f_null", "f_null", "f_null", "f_rubble_rock", "f_cattails" ],
+        "%": [ "f_null", "f_rubble_rock" ]
+      },
+      "items": {
+        ".": { "item": "minerals_swamp", "chance": 2 },
+        "%": { "item": "minerals_swamp", "chance": 30 }
+      }
+	}
 }
 ]

--- a/Mining_Mod/overmap_override.json
+++ b/Mining_Mod/overmap_override.json
@@ -1,0 +1,101 @@
+[
+    {
+        "type" : "overmap_special",
+        "id" : "Crater",
+        "copy-from" : "Crater",
+        "overmaps" : [
+            { "point":[0,0,0], "overmap": "crater"},
+            { "point":[0,0,-1], "overmap": "vein_maybe"}
+        ]
+    },
+    {
+        "type" : "overmap_special",
+        "id" : "Toxic Waste Dump",
+        "copy-from" : "Toxic Waste Dump",
+        "overmaps" : [
+            { "point":[0,0,0], "overmap": "toxic_dump"},
+            { "point":[0,0,-1], "overmap": "vein_maybe"}
+        ]
+    },
+    {
+        "type" : "overmap_special",
+        "id" : "Motel",
+        "copy-from" : "Motel",
+        "occurrences" : [0, 5]
+    },
+    {
+        "type" : "overmap_special",
+        "id" : "Home Improvement Superstore",
+        "copy-from" : "Home Improvement Superstore",
+        "occurrences" : [0, 2]
+    },
+    {
+        "type" : "overmap_special",
+        "id" : "FEMA Camp",
+        "copy-from" : "FEMA Camp",
+        "occurrences" : [1, 5]
+    },
+    {
+        "type" : "overmap_special",
+        "id" : "cemetery_religious",
+        "copy-from" : "cemetery_religious",
+        "occurrences" : [1, 5]
+    },
+    {
+        "type" : "overmap_special",
+        "id" : "Gas Station",
+        "copy-from" : "Gas Station",
+        "occurrences" : [1, 4]
+    },
+    {
+        "type" : "overmap_special",
+        "id" : "campsite_a",
+        "copy-from" : "campsite_a",
+        "occurrences" : [1, 5]
+    },
+    {
+        "type" : "overmap_special",
+        "id" : "bog",
+        "copy-from" : "bog",
+        "overmaps" : [
+            { "point":[0,0,0], "overmap": "pond_swamp"},
+            { "point":[0,0,-1], "overmap": "vein_hematite"}
+        ]
+    },
+    {
+        "type" : "overmap_special",
+        "id" : "Cabin",
+        "copy-from" : "Cabin",
+        "overmaps" : [
+            { "point":[0,0,0], "overmap": "cabin"},
+            { "point":[0,0,-1], "overmap": "vein_maybe"}
+        ]
+    },
+    {
+        "type" : "overmap_special",
+        "id" : "Strange Cabin",
+        "copy-from" : "Strange Cabin",
+        "overmaps" : [
+            { "point":[0,0,0], "overmap": "cabin_strange"},
+            { "point":[0,0,-1], "overmap": "cabin_strange_b"},
+            { "point":[0,0,-2], "overmap": "vein_maybe"},
+            { "point":[0,0,-3], "overmap": "vein_maybe"},
+            { "point":[0,0,-4], "overmap": "vein_maybe"},
+            { "point":[0,0,-5], "overmap": "vein_maybe"}
+        ]
+    },
+    {
+        "type" : "overmap_special",
+        "id" : "Standing stones",
+        "copy-from" : "Standing stones",
+        "overmaps" : [
+            { "point":[0,0,0], "overmap": "standing_stones"},
+            { "point":[0,0,-1], "overmap": "empty_rock"},
+            { "point":[0,0,-2], "overmap": "vein_maybe"},
+            { "point":[0,0,-3], "overmap": "vein_maybe"},
+            { "point":[0,0,-4], "overmap": "vein_maybe"},
+            { "point":[0,0,-5], "overmap": "vein_maybe"}
+
+        ]
+    }
+]

--- a/Mining_Mod/overmap_override.json
+++ b/Mining_Mod/overmap_override.json
@@ -19,15 +19,21 @@
     },
     {
         "type" : "overmap_special",
+        "id" : "Hotel",
+        "copy-from" : "Hotel",
+        "occurrences" : [0, 2]
+    },
+    {
+        "type" : "overmap_special",
         "id" : "Motel",
         "copy-from" : "Motel",
         "occurrences" : [0, 5]
     },
     {
         "type" : "overmap_special",
-        "id" : "Home Improvement Superstore",
-        "copy-from" : "Home Improvement Superstore",
-        "occurrences" : [0, 2]
+        "id" : "Gas Station",
+        "copy-from" : "Gas Station",
+        "occurrences" : [0, 4]
     },
     {
         "type" : "overmap_special",
@@ -37,15 +43,69 @@
     },
     {
         "type" : "overmap_special",
-        "id" : "cemetery_religious",
-        "copy-from" : "cemetery_religious",
-        "occurrences" : [1, 5]
+        "id" : "Radio Tower",
+        "copy-from" : "Radio Tower",
+        "occurrences" : [0, 5]
     },
     {
         "type" : "overmap_special",
-        "id" : "Gas Station",
-        "copy-from" : "Gas Station",
-        "occurrences" : [1, 4]
+        "id" : "Apartments_Con",
+        "copy-from" : "Radio Tower",
+        "occurrences" : [0, 5]
+    },
+    {
+        "type" : "overmap_special",
+        "id" : "Apartments_Mod",
+        "copy-from" : "Apartments_Mod",
+        "occurrences" : [0, 4]
+    },
+    {
+        "type" : "overmap_special",
+        "id" : "Office Tower",
+        "copy-from" : "Office Tower",
+        "occurrences" : [0, 5]
+    },
+    {
+        "type" : "overmap_special",
+        "id" : "Evac Shelter",
+        "copy-from" : "Evac Shelter",
+        "occurrences" : [1, 10]
+    },
+    {
+        "type" : "overmap_special",
+        "id" : "power_station_large",
+        "copy-from" : "power_station_large",
+        "occurrences" : [0, 3]
+    },
+    {
+        "type" : "overmap_special",
+        "id" : "Home Improvement Superstore",
+        "copy-from" : "Home Improvement Superstore",
+        "occurrences" : [0, 3]
+    },
+    {
+        "type" : "overmap_special",
+        "id" : "rest_stop",
+        "copy-from" : "rest_stop",
+        "occurrences" : [0, 2]
+    },
+    {
+        "type" : "overmap_special",
+        "id" : "roadstop_a",
+        "copy-from" : "roadstop_a",
+        "occurrences" : [0, 2]
+    },
+    {
+        "type" : "overmap_special",
+        "id" : "roadstop_b",
+        "copy-from" : "roadstop_b",
+        "occurrences" : [0, 2]
+    },
+    {
+        "type" : "overmap_special",
+        "id" : "cemetery_religious",
+        "copy-from" : "cemetery_religious",
+        "occurrences" : [0, 5]
     },
     {
         "type" : "overmap_special",

--- a/Mining_Mod/overmap_specials.json
+++ b/Mining_Mod/overmap_specials.json
@@ -8,7 +8,7 @@
         ],
         "locations" : [ "forest" ],
         "city_distance" : [0, -1],
-        "occurrences" : [1, 200],
+        "occurrences" : [4, 200],
         "rotate" : true,
         "flags" : [ "CLASSIC" ]
     },
@@ -21,7 +21,20 @@
         ],
         "locations" : [ "field" ],
         "city_distance" : [0, -1],
-        "occurrences" : [1, 200],
+        "occurrences" : [4, 200],
+        "rotate" : true,
+        "flags" : [ "CLASSIC" ]
+    },
+    {
+        "type" : "overmap_special",
+        "id" : "vein_swamp_shallow",
+        "overmaps" : [
+            { "point":[0,0,0], "overmap": "swamp_hematite"},
+            { "point":[0,0,-1], "overmap": "vein_hematite"}
+        ],
+        "locations" : [ "swamp" ],
+        "city_distance" : [0, -1],
+        "occurrences" : [5, 200],
         "rotate" : true,
         "flags" : [ "CLASSIC" ]
     },
@@ -38,7 +51,7 @@
         ],
         "locations" : [ "forest" ],
         "city_distance" : [0, -1],
-        "occurrences" : [1, 200],
+        "occurrences" : [5, 200],
         "rotate" : true,
         "flags" : [ "CLASSIC" ]
     },
@@ -46,7 +59,7 @@
         "type" : "overmap_special",
         "id" : "vein_field_deep",
         "overmaps" : [
-            { "point":[0,0,0], "overmap": "field_shallow"},
+            { "point":[0,0,0], "overmap": "field_deep"},
             { "point":[0,0,-1], "overmap": "empty_rock"},
             { "point":[0,0,-2], "overmap": "vein_maybe"},
             { "point":[0,0,-3], "overmap": "vein_maybe"},
@@ -55,7 +68,24 @@
         ],
         "locations" : [ "field" ],
         "city_distance" : [0, -1],
-        "occurrences" : [1, 200],
+        "occurrences" : [3, 200],
+        "rotate" : true,
+        "flags" : [ "CLASSIC" ]
+    },
+    {
+        "type" : "overmap_special",
+        "id" : "vein_swamp_deep",
+        "overmaps" : [
+            { "point":[0,0,0], "overmap": "swamp_vein"},
+            { "point":[0,0,-1], "overmap": "empty_rock"},
+            { "point":[0,0,-2], "overmap": "vein_maybe"},
+            { "point":[0,0,-3], "overmap": "vein_maybe"},
+            { "point":[0,0,-4], "overmap": "vein_maybe"},
+            { "point":[0,0,-5], "overmap": "vein_maybe"}
+        ],
+        "locations" : [ "swamp" ],
+        "city_distance" : [0, -1],
+        "occurrences" : [3, 200],
         "rotate" : true,
         "flags" : [ "CLASSIC" ]
     }

--- a/Mining_Mod/overmap_specials.json
+++ b/Mining_Mod/overmap_specials.json
@@ -8,7 +8,7 @@
         ],
         "locations" : [ "forest" ],
         "city_distance" : [0, -1],
-        "occurrences" : [4, 200],
+        "occurrences" : [3, 200],
         "rotate" : true,
         "flags" : [ "CLASSIC" ]
     },
@@ -21,7 +21,7 @@
         ],
         "locations" : [ "field" ],
         "city_distance" : [0, -1],
-        "occurrences" : [4, 200],
+        "occurrences" : [3, 200],
         "rotate" : true,
         "flags" : [ "CLASSIC" ]
     },
@@ -34,7 +34,7 @@
         ],
         "locations" : [ "swamp" ],
         "city_distance" : [0, -1],
-        "occurrences" : [5, 200],
+        "occurrences" : [3, 200],
         "rotate" : true,
         "flags" : [ "CLASSIC" ]
     },
@@ -51,7 +51,7 @@
         ],
         "locations" : [ "forest" ],
         "city_distance" : [0, -1],
-        "occurrences" : [5, 200],
+        "occurrences" : [3, 200],
         "rotate" : true,
         "flags" : [ "CLASSIC" ]
     },

--- a/Mining_Mod/overmap_specials.json
+++ b/Mining_Mod/overmap_specials.json
@@ -8,7 +8,7 @@
         ],
         "locations" : [ "forest" ],
         "city_distance" : [0, -1],
-        "occurrences" : [3, 200],
+        "occurrences" : [2, 200],
         "rotate" : true,
         "flags" : [ "CLASSIC" ]
     },
@@ -21,7 +21,7 @@
         ],
         "locations" : [ "field" ],
         "city_distance" : [0, -1],
-        "occurrences" : [3, 200],
+        "occurrences" : [2, 200],
         "rotate" : true,
         "flags" : [ "CLASSIC" ]
     },
@@ -34,7 +34,7 @@
         ],
         "locations" : [ "swamp" ],
         "city_distance" : [0, -1],
-        "occurrences" : [3, 200],
+        "occurrences" : [2, 200],
         "rotate" : true,
         "flags" : [ "CLASSIC" ]
     },
@@ -51,7 +51,7 @@
         ],
         "locations" : [ "forest" ],
         "city_distance" : [0, -1],
-        "occurrences" : [3, 200],
+        "occurrences" : [2, 200],
         "rotate" : true,
         "flags" : [ "CLASSIC" ]
     },
@@ -68,7 +68,7 @@
         ],
         "locations" : [ "field" ],
         "city_distance" : [0, -1],
-        "occurrences" : [3, 200],
+        "occurrences" : [2, 200],
         "rotate" : true,
         "flags" : [ "CLASSIC" ]
     },
@@ -85,7 +85,7 @@
         ],
         "locations" : [ "swamp" ],
         "city_distance" : [0, -1],
-        "occurrences" : [3, 200],
+        "occurrences" : [2, 200],
         "rotate" : true,
         "flags" : [ "CLASSIC" ]
     }

--- a/Mining_Mod/overmap_terrain.json
+++ b/Mining_Mod/overmap_terrain.json
@@ -10,6 +10,15 @@
     },
     {
         "type" : "overmap_terrain",
+        "id" : "vein_hematite",
+        "name" : "mineral vein",
+        "sym" : 37,
+        "color" : "light_gray",
+        "see_cost" : 5,
+        "allow_road" : true
+    },
+    {
+        "type" : "overmap_terrain",
         "id" : "vein_maybe",
         "name" : "mineral vein?",
         "sym" : 37,
@@ -19,7 +28,7 @@
     },{
         "type" : "overmap_terrain",
         "id" : "field_shallow",
-        "name" : "field",
+        "name" : "field?",
         "sym" : 46,
         "color" : "brown",
         "see_cost" : 2,
@@ -29,7 +38,7 @@
     },{
         "type" : "overmap_terrain",
         "id" : "field_deep",
-        "name" : "field",
+        "name" : "field?",
         "sym" : 46,
         "color" : "brown",
         "see_cost" : 2,
@@ -39,12 +48,34 @@
     },{
         "type" : "overmap_terrain",
         "id" : "forest_vein",
-        "name" : "forest",
+        "name" : "forest?",
         "sym" : 70,
         "color" : "green",
         "see_cost" : 3,
         "extras" : "field",
         "spawns" : { "group": "GROUP_FOREST", "population": [0, 3], "chance": 80 },
+        "allow_road" : true
+    },
+    {
+        "type" : "overmap_terrain",
+        "id" : "swamp_hematite",
+        "name" : "swamp?",
+        "sym" : 70,
+        "color" : "cyan",
+        "see_cost" : 4,
+        "extras" : "field",
+        "spawns" : { "group": "GROUP_SWAMP", "population": [1, 4], "chance": 100 },
+        "allow_road" : true
+    },
+    {
+        "type" : "overmap_terrain",
+        "id" : "swamp_vein",
+        "name" : "swamp?",
+        "sym" : 70,
+        "color" : "cyan",
+        "see_cost" : 4,
+        "extras" : "field",
+        "spawns" : { "group": "GROUP_SWAMP", "population": [1, 4], "chance": 100 },
         "allow_road" : true
     }
 ]

--- a/Mining_Mod/recipes.json
+++ b/Mining_Mod/recipes.json
@@ -2,7 +2,6 @@
   {
     "result": "copper",
     "type": "recipe",
-    "result_mult": 2,
     "id_suffix": "native",
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_MATERIALS",
@@ -11,20 +10,17 @@
     "time": 12500,
     "batch_time_factors": [ 90, 4 ],
     "autolearn": true,
+    "result_mult": 2,
     "tools": [
       [ [ "tongs", -1 ] ],
       [ [ "crucible", -1 ] ],
-      [
-        [ "toolset", 10 ],
-        [ "fire", -1 ]
-      ]
+      [ [ "toolset", 10 ], [ "fire", -1 ] ]
     ],
     "components": [ [ [ "chunk_copper", 1 ] ] ]
   },
   {
     "result": "silver_small",
     "type": "recipe",
-    "result_mult": 4,
     "id_suffix": "native",
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_MATERIALS",
@@ -33,20 +29,17 @@
     "time": 12500,
     "batch_time_factors": [ 90, 4 ],
     "autolearn": true,
+    "result_mult": 4,
     "tools": [
       [ [ "tongs", -1 ] ],
       [ [ "crucible", -1 ] ],
-      [
-        [ "toolset", 10 ],
-        [ "fire", -1 ]
-      ]
+      [ [ "toolset", 10 ], [ "fire", -1 ] ]
     ],
     "components": [ [ [ "chunk_silver", 1 ] ] ]
   },
   {
     "result": "gold_small",
     "type": "recipe",
-    "result_mult": 4,
     "id_suffix": "native",
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_MATERIALS",
@@ -55,13 +48,11 @@
     "time": 12500,
     "batch_time_factors": [ 90, 4 ],
     "autolearn": true,
+    "result_mult": 4,
     "tools": [
       [ [ "tongs", -1 ] ],
       [ [ "crucible", -1 ] ],
-      [
-        [ "toolset", 10 ],
-        [ "fire", -1 ]
-      ]
+      [ [ "toolset", 10 ], [ "fire", -1 ] ]
     ],
     "components": [ [ [ "chunk_gold", 1 ] ] ]
   },
@@ -79,18 +70,13 @@
     "tools": [
       [ [ "tongs", -1 ] ],
       [ [ "crucible", -1 ] ],
-      [
-        [ "toolset", 10 ],
-        [ "fire", -1 ]
-      ]
+      [ [ "toolset", 10 ], [ "fire", -1 ] ]
     ],
     "components": [ [ [ "chunk_aluminum", 1 ] ] ]
   },
   {
     "result": "lead",
     "type": "recipe",
-    "result_mult": 4,
-    "byproducts": [ [ "silver_small" ] ],
     "id_suffix": "smelt",
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_MATERIALS",
@@ -99,19 +85,17 @@
     "time": 40000,
     "batch_time_factors": [ 90, 4 ],
     "book_learn": [ [ "recipe_bullets", 4 ], [ "textbook_fabrication", 5 ], [ "welding_book", 3 ] ],
+    "result_mult": 4,
+    "byproducts": [ [ "silver_small" ] ],
     "tools": [
       [ [ "crucible", -1 ] ],
-      [
-        [ "forge", 60 ],
-        [ "char_forge", 60 ]
-      ]
+      [ [ "forge", 60 ], [ "char_forge", 60 ] ]
     ],
     "components": [ [ [ "chunk_galena", 1 ] ] ]
   },
   {
     "result": "steel_lump",
     "type": "recipe",
-    "result_mult": 2,
     "id_suffix": "smelt",
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_MATERIALS",
@@ -120,23 +104,36 @@
     "time": 60000,
     "batch_time_factors": [ 90, 4 ],
     "book_learn": [ [ "textbook_armschina", 5 ], [ "textbook_fabrication", 6 ], [ "welding_book", 4 ] ],
+    "result_mult": 2,
     "tools": [
       [ [ "crucible", -1 ] ],
-      [
-         [ "forge", 80 ],
-         [ "char_forge", 80 ]
-      ]
+      [ [ "forge", 80 ], [ "char_forge", 80 ] ]
     ],
     "components": [
       [ [ "chunk_hematite", 1 ] ],
-      [
-        [ "material_shrd_limestone", 1 ],
-        [ "material_limestone", 10 ]
-      ],
-      [
-        [ "charcoal", 10 ],
-        [ "coal_lump", 10 ]
-      ]
+      [ [ "material_shrd_limestone", 1 ], [ "material_limestone", 10 ] ],
+      [ [ "charcoal", 10 ], [ "coal_lump", 10 ] ]
+    ]
+  },
+  {
+    "result": "pickaxe_copper",
+    "type": "recipe",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_TOOLS",
+    "skill_used": "fabrication",
+    "difficulty": 6,
+    "time": 420000,
+    "autolearn": true,
+    "book_learn": [ [ "textbook_carpentry", 4 ], [ "textbook_fabrication", 5 ] ],
+    "qualities": [ { "id": "HAMMER", "level": 3 } ],
+    "tools": [
+      [ [ "tongs", -1 ] ],
+      [ [ "crucible", -1 ] ],
+      [ [ "forge", 200 ], [ "char_forge", 40 ], [ "oxy_torch", 40 ] ]
+    ],
+    "components": [
+      [ [ "2x4", 2 ], [ "stick", 4 ] ],
+      [ [ "scrap_copper", 5 ], [ "copper", 500 ] ]
     ]
   }
 ]


### PR DESCRIPTION
Implemented a change to overmap specials originally suggested to me by @pisskop, as implemented in their mod. In this case it is applied in as minimal a manner as possible via 'copy-from', to reduce only the minimum occurrences and give a select few overmaps potential for hiding veins underneath.

This allowed me to increase the minimums without risking any load errors duw to number of minimum mandated specials, while ensuring that combining this mod with others (such as More Locations) does not go over the mandated limit. Compatibility with PK Rebalance is unknown, but only interaction with be some disagreement with occurrence number, and a few instances of different overmaps.

Additionally made some minor changes to surface indicators and marked them in a way that attentive players can locate them on the map, and implemented veins appearing underneath swamps. These include two variations. In addition to deep mineral veins, shallow veins occur in the form of bog iron, with small amounts of ore appearing on the surface. The vein underneath will always be iron ore (realistically should be limonite or goethite, but using hematite for now).

Lastly, implemented a copper variant of the pickaxe. Recipe is more extensive than existing copper tools, both for balance reasons and on the assumption that it is cast into the desired shape before the end is work-hardened, rather than annealing and hammering out a makeshift tool.

Changes implemented in the form of a pull request in the interest of receiving feedback about changes, such as from @borkborkgoesthecode.