### PR TITLE
Replaced "allow_road": true, with ALLOW_OVERRIDE flag.

### DIFF
--- a/Mining_Mod/overmap_terrain.json
+++ b/Mining_Mod/overmap_terrain.json
@@ -6,8 +6,7 @@
         "sym" : 37,
         "color" : "light_gray",
         "see_cost" : 5,
-        "allow_road" : true,
-        "flags" : [ "NO_ROTATE" ]
+        "flags" : [ "ALLOW_OVERRIDE", "NO_ROTATE" ]
     },
     {
         "type" : "overmap_terrain",
@@ -16,8 +15,7 @@
         "sym" : 37,
         "color" : "light_gray",
         "see_cost" : 5,
-        "allow_road" : true,
-        "flags" : [ "NO_ROTATE" ]
+        "flags" : [ "ALLOW_OVERRIDE", "NO_ROTATE" ]
     },
     {
         "type" : "overmap_terrain",
@@ -26,8 +24,7 @@
         "sym" : 37,
         "color" : "light_gray",
         "see_cost" : 5,
-        "allow_road" : true,
-        "flags" : [ "NO_ROTATE" ]
+        "flags" : [ "ALLOW_OVERRIDE", "NO_ROTATE" ]
     },{
         "type" : "overmap_terrain",
         "id" : "field_shallow",
@@ -37,8 +34,7 @@
         "see_cost" : 2,
         "extras" : "field",
         "spawns" : { "group": "GROUP_FOREST", "population": [0, 1], "chance": 80 },
-        "allow_road" : true,
-        "flags" : [ "NO_ROTATE" ]
+        "flags" : [ "ALLOW_OVERRIDE", "NO_ROTATE" ]
     },{
         "type" : "overmap_terrain",
         "id" : "field_deep",
@@ -48,8 +44,7 @@
         "see_cost" : 2,
         "extras" : "field",
         "spawns" : { "group": "GROUP_FOREST", "population": [0, 1], "chance": 80 },
-        "allow_road" : true,
-        "flags" : [ "NO_ROTATE" ]
+        "flags" : [ "ALLOW_OVERRIDE", "NO_ROTATE" ]
     },{
         "type" : "overmap_terrain",
         "id" : "forest_vein",
@@ -59,8 +54,7 @@
         "see_cost" : 3,
         "extras" : "field",
         "spawns" : { "group": "GROUP_FOREST", "population": [0, 3], "chance": 80 },
-        "allow_road" : true,
-        "flags" : [ "NO_ROTATE" ]
+        "flags" : [ "ALLOW_OVERRIDE", "NO_ROTATE" ]
     },
     {
         "type" : "overmap_terrain",
@@ -71,8 +65,7 @@
         "see_cost" : 4,
         "extras" : "field",
         "spawns" : { "group": "GROUP_SWAMP", "population": [1, 4], "chance": 100 },
-        "allow_road" : true,
-        "flags" : [ "NO_ROTATE" ]
+        "flags" : [ "ALLOW_OVERRIDE", "NO_ROTATE" ]
     },
     {
         "type" : "overmap_terrain",
@@ -83,7 +76,6 @@
         "see_cost" : 4,
         "extras" : "field",
         "spawns" : { "group": "GROUP_SWAMP", "population": [1, 4], "chance": 100 },
-        "allow_road" : true,
-        "flags" : [ "NO_ROTATE" ]
+        "flags" : [ "ALLOW_OVERRIDE", "NO_ROTATE" ]
     }
 ]


### PR DESCRIPTION
While looking at Mining Mod and the overmap updates made in Cataclysm: DDA, I found that Mining Mod uses deprecated fields in overmap terrain. They have been replaced here.