### PR TITLE
Adds bone pickaxe

### DIFF
--- a/Mining_Mod/construction.json
+++ b/Mining_Mod/construction.json
@@ -1,0 +1,28 @@
+[
+    {
+        "type" : "construction",
+        "description" : "Make stone anvil",
+        "category" : "FURN",
+        "required_skills" : [ [ "fabrication", 4 ], [ "survival", 2 ] ],
+        "time" : 120,
+        "qualities": [ [ { "id": "HAMMER", "level": 2 } ] ],
+        "tools" : [
+            [ [ "pickaxe", -1 ], [ "jackhammer", 30 ], [ "elec_jackhammer", 30 ] ]
+        ],
+        "pre_terrain" : "f_boulder_medium",
+        "post_terrain" : "f_anvil_stone"
+    },
+    {
+        "type" : "construction",
+        "description" : "Make stone anvil",
+        "category" : "FURN",
+        "required_skills" : [ [ "fabrication", 4 ], [ "survival", 2 ] ],
+        "time" : 120,
+        "qualities": [ [ { "id": "HAMMER", "level": 2 } ] ],
+        "tools" : [
+            [ [ "pickaxe", -1 ], [ "jackhammer", 30 ], [ "elec_jackhammer", 30 ] ]
+        ],
+        "pre_terrain" : "f_boulder_large",
+        "post_terrain" : "f_anvil_stone"
+    }
+]

--- a/Mining_Mod/furniture.json
+++ b/Mining_Mod/furniture.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "f_anvil_stone",
+    "type": "furniture",
+    "name": "stone anvil",
+    "symbol": "^",
+    "color": [ "dkgray" ],
+    "move_cost_mod": 3,
+    "required_str": 8,
+    "crafting_pseudo_item": "anvil",
+    "bash": {
+      "str_min": 12,
+      "str_max": 36,
+      "sound": "smash!",
+      "sound_fail": "thump.",
+      "items": [ { "item": "rock", "count": [ 1, 5 ] } ]
+    },
+    "flags": [ "TRANSPARENT", "MINEABLE", "NOITEM", "MOUNTABLE", "TINY" ]
+  }
+]

--- a/Mining_Mod/item_groups.json
+++ b/Mining_Mod/item_groups.json
@@ -1,0 +1,23 @@
+[
+  {
+    "id": "survivorzed_extra",
+    "type": "item_group",
+    "items": [ [ "pickaxe_copper", 1 ] ]
+  },
+  {
+    "id": "mine_storage",
+    "type": "item_group",
+    "items": [
+      [ "chunk_hematite", 3 ],
+      [ "chunk_galena", 2 ]
+    ]
+  },
+  {
+    "id": "museum_primitive",
+    "type": "item_group",
+    "items": [
+      { "item": "pickaxe_bone", "prob": 10, "charges-min": 30, "charges-max": 60 },
+      [ "pickaxe_copper", 5 ]
+    ]
+  }
+]

--- a/Mining_Mod/items.json
+++ b/Mining_Mod/items.json
@@ -141,7 +141,7 @@
     "to_hit": -3,
     "bashing": 10,
     "cutting": 3,
-    "material": [ "wood", "bone" ],
+    "material": [ "wood" ],
     "symbol": "/",
     "color": "white",
     "initial_charges": 90,

--- a/Mining_Mod/items.json
+++ b/Mining_Mod/items.json
@@ -128,5 +128,26 @@
     "color": "light_red",
     "use_action": "PICKAXE",
     "flags": [ "SPEAR", "NONCONDUCTIVE", "FRAGILE" ]
+  },
+  {
+    "id": "pickaxe_bone",
+    "type": "TOOL",
+    "name": "bone pickaxe",
+    "description": "This is a primitive pickaxe, traditionally made from antler or bone, and fire-hardened for greater hardness.  It will wear out with use, but still suitable for striking the earth.",
+    "sub": "jackhammer",
+    "weight": 760,
+    "volume": 10,
+    "price": 800,
+    "to_hit": -3,
+    "bashing": 10,
+    "cutting": 3,
+    "material": [ "wood", "bone" ],
+    "symbol": "/",
+    "color": "white",
+    "initial_charges": 90,
+    "max_charges": 90,
+    "charges_per_use": 10,
+    "use_action": "PICKAXE",
+    "flags": [ "SPEAR", "FRAGILE" ]
   }
 ]

--- a/Mining_Mod/recipes.json
+++ b/Mining_Mod/recipes.json
@@ -146,5 +146,24 @@
       [ [ "2x4", 2 ], [ "stick", 4 ] ],
       [ [ "scrap_copper", 5 ], [ "copper", 500 ] ]
     ]
+  },
+  {
+    "result": "pickaxe_bone",
+    "type": "recipe",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_TOOLS",
+    "skill_used": "fabrication",
+    "difficulty": 5,
+    "skills_required": [ "survival", 3 ],
+    "time": 15000,
+    "autolearn": true,
+    "book_learn": [ [ "survival_book", 3 ], [ "textbook_survival", 4 ] ],
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "tools": [ [ [ "fire", -1 ] ] ],
+    "components": [
+      [ [ "2x4", 2 ], [ "stick", 4 ] ],
+      [ [ "bone", 4 ], [ "bone_human", 4 ] ],
+      [ [ "cordage_short", 2, "LIST" ], [ "sinew", 40 ], [ "thread", 40 ], [ "plant_fibre", 40 ], [ "yarn", 40 ] ]
+    ]
   }
 ]


### PR DESCRIPTION
This adds the option to craft a pick made from bone (antlers not yet being an option in-game at present) as a way to initiate mining if metal is lacking. The recipe cites use of fire-hardening as a method of hardening the material, which is more useful for antler tools but also effective on bone.

Charges and charges per use are set so that a single pick will last for 9 tiles if mining stone, or 3 if mining down levels. Since bone is the main resource consumed in crafting it, feedback on what level of durability would be appropriate would be desirable.

Finally, made some additions to item groups, mainly in allowing hematite or galena to appear in mine storage, and for variant pickaxes to rarely appear where appropriate.