### PR TITLE
Rebalancing of ore weights and yields

### DIFF
--- a/Mining_Mod/items.json
+++ b/Mining_Mod/items.json
@@ -11,7 +11,8 @@
     "description" : "A large chunk of copper, in its native state.  It only needs to be worked into a more usable shape.",
     "material" : "copper",
     "volume" : 4,
-    "weight" : 2600,
+    "//" : "Density of one liter of copper, item is native metal.",
+    "weight" : 8960,
     "bashing" : 2,
     "ammo_type" : "components"
   },
@@ -27,8 +28,9 @@
     "description" : "A large chunk of silver, in its native state.  It only needs to be molded into a more usable shape.",
     "material" : "silver",
     "volume" : 4,
-    "weight" : 2500,
-    "bashing" : 2,
+    "//" : "Density of one liter of silver, item is native metal.",
+    "weight" : 10490,
+    "bashing" : 3,
     "ammo_type" : "components"
   },
   {
@@ -43,8 +45,9 @@
     "description" : "A large chunk of native gold, a rare find.  It only needs to be molded into a more usable shape.",
     "material" : "gold",
     "volume" : 4,
-    "weight" : 3000,
-    "bashing" : 3,
+    "//" : "Density of one liter of gold, item is native metal.  Massivelly heavy.",
+    "weight" : 19320,
+    "bashing" : 4,
     "ammo_type" : "components"
   },
   {
@@ -59,7 +62,8 @@
     "description" : "A large chunk of native aluminum, which would have been priceless before other ways to obtain aluminum were invented.  It needs to be cast into an ingot.",
     "material" : "aluminum",
     "volume" : 4,
-    "weight" : 2000,
+    "//" : "Density of one liter of aluminum, item is native metal.",
+    "weight" : 2700,
     "bashing" : 1,
     "ammo_type" : "components"
   },
@@ -75,7 +79,8 @@
     "description" : "A large chunk of cassiterite, an ore of tin.  It only needs to be smelted into a usable form.",
     "material" : "stone",
     "volume" : 4,
-    "weight" : 3100,
+    "//" : "One liter, roughly 6.26 grams per cubic centimeter.",
+    "weight" : 6260,
     "bashing" : 2,
     "ammo_type" : "components"
   },
@@ -91,7 +96,8 @@
     "description" : "A large chunk of galena, a lead ore with small amounts of silver.  It only needs to be smelted into a usable form.",
     "material" : "stone",
     "volume" : 4,
-    "weight" : 3400,
+    "//" : "One liter, roughly 7.6 grams per cubic centimeter.",
+    "weight" : 7600,
     "bashing" : 3,
     "ammo_type" : "components"
   },
@@ -107,7 +113,8 @@
     "description" : "A large chunk of hematite, an ore of iron.  It only needs to be smelted into a usable form.",
     "material" : "stone",
     "volume" : 4,
-    "weight" : 2400,
+    "//" : "One liter, roughly 5.04 grams per cubic centimeter.",
+    "weight" : 5040,
     "bashing" : 2,
     "ammo_type" : "components"
   },

--- a/Mining_Mod/recipes.json
+++ b/Mining_Mod/recipes.json
@@ -10,7 +10,8 @@
     "time": 12500,
     "batch_time_factors": [ 90, 4 ],
     "autolearn": true,
-    "result_mult": 2,
+    "//": "Yield is just over 98% by weight, each output of copper is 400 weight.  Volume of output is massively oversize however.",
+    "result_mult": 22,
     "tools": [
       [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ],
       [ [ "fire", -1 ], [ "toolset", 10 ] ]
@@ -28,7 +29,8 @@
     "time": 12500,
     "batch_time_factors": [ 90, 4 ],
     "autolearn": true,
-    "result_mult": 4,
+    "//": "Yield is just over 97% by weight, each output of silver is 300 weight.  Volume of output is massively oversize however.",
+    "result_mult": 34,
     "tools": [
       [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ],
       [ [ "fire", -1 ], [ "toolset", 10 ] ]
@@ -46,7 +48,8 @@
     "time": 12500,
     "batch_time_factors": [ 90, 4 ],
     "autolearn": true,
-    "result_mult": 4,
+    "//": "Yield is just over 98% by weight, each output of gold is 500 weight.  Volume of output is massively oversize however.",
+    "result_mult": 38,
     "tools": [
       [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ],
       [ [ "fire", -1 ], [ "toolset", 10 ] ]
@@ -64,6 +67,8 @@
     "time": 25000,
     "batch_time_factors": [ 90, 4 ],
     "autolearn": true,
+    "//": "Yield is just 100% by weight, each output of aluminum is 675 weight.",
+    "result_mult": 4,
     "tools": [
       [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ],
       [ [ "fire", -1 ], [ "toolset", 10 ] ]
@@ -82,7 +87,8 @@
     "batch_time_factors": [ 90, 4 ],
     "autolearn": true,
     "book_learn": [ [ "recipe_bullets", 2 ], [ "textbook_fabrication", 2 ], [ "welding_book", 2 ] ],
-    "result_mult": 2,
+    "//": "Cassiterite has around 86% yield, yield here is just over 76%, due to one output of 600 grams.  Output volume is still oversize.",
+    "result_mult": 8,
     "using": [ [ "forging_standard", 3 ] ],
     "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [ [ [ "chunk_cassiterite", 1 ] ] ]
@@ -99,7 +105,8 @@
     "batch_time_factors": [ 90, 4 ],
     "autolearn": true,
     "book_learn": [ [ "recipe_bullets", 2 ], [ "textbook_fabrication", 2 ], [ "welding_book", 2 ] ],
-    "result_mult": 4,
+    "//": "Galena has around 86% yield of lead, yield here is just over 82%, due to one output weighing 300 grams.  Silver output is around double the expected 2% yield due to minumum of 300 grams.  Output volume is still oversize.",
+    "result_mult": 21,
     "byproducts": [ [ "silver_small" ] ],
     "using": [ [ "forging_standard", 3 ] ],
     "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
@@ -117,7 +124,9 @@
     "batch_time_factors": [ 90, 4 ],
     "autolearn": true,
     "book_learn": [ [ "textbook_armschina", 3 ], [ "textbook_fabrication", 3 ], [ "welding_book", 3 ] ],
-    "result_mult": 2,
+    "//": "Hematite has around 70% yield of iron, total yield here is just over 69% at 3500 grams of steel.  Estimated 2% carbon content has minimal effect on these numbers.",
+    "result_mult": 3,
+    "byproducts": [ [ "steel_chunk", 2 ] ],
     "using": [ [ "forging_standard", 4 ] ],
     "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [

--- a/Mining_Mod/terrain.json
+++ b/Mining_Mod/terrain.json
@@ -134,7 +134,7 @@
             "ter_set": "t_rock_floor",
             "items": [
                 { "item": "rock", "count": [3, 7] },
-                { "item": "chunk_silver", "count": [1, 3], "prob": 80 }
+                { "item": "chunk_silver", "count": [1, 2], "prob": 80 }
             ]
         }
     },
@@ -154,7 +154,7 @@
             "ter_set": "t_rock_floor",
             "items": [
                 { "item": "rock", "count": [3, 7] },
-                { "item": "chunk_gold", "count": [1, 3], "prob": 80 }
+                { "item": "chunk_gold", "count": [1, 2], "prob": 80 }
             ]
         }
     },
@@ -194,7 +194,7 @@
             "ter_set": "t_rock_floor",
             "items": [
                 { "item": "rock", "count": [3, 7] },
-                { "item": "chunk_cassiterite", "count": [1, 3], "prob": 80 }
+                { "item": "chunk_cassiterite", "count": [2, 4], "prob": 80 }
             ]
         }
     },
@@ -214,7 +214,7 @@
             "ter_set": "t_rock_floor",
             "items": [
                 { "item": "rock", "count": [3, 7] },
-                { "item": "chunk_galena", "count": [1, 3], "prob": 80 }
+                { "item": "chunk_galena", "count": [2, 4], "prob": 80 }
             ]
         }
     },
@@ -234,7 +234,7 @@
             "ter_set": "t_rock_floor",
             "items": [
                 { "item": "rock", "count": [3, 7] },
-                { "item": "chunk_hematite", "count": [1, 3], "prob": 80 }
+                { "item": "chunk_hematite", "count": [2, 4], "prob": 80 }
             ]
         }
     }


### PR DESCRIPTION
This pull request alters the weights and yields of most of the ore added to the mod. Weights for ore are based off findings for density of cassiterite, galena, and hematite, or for pure metal in the case of native metals. These operate on the assumption that a chunk is indeed a liter in volume, rather than a volume-inefficient shape as used in scrap metal, chunks of steel, etc. This is done simply to make the math easier, but can be altered if needed.

Yields are as close to what I could research as possible using result multipliers, rounded down. Native metals are as close to 100% yield by weight (as the count of the output allows) as can be done.

Some anomalies however, that someone (@Coolthulhu?) should be made aware of. Output has no volume-sanity despite attempting to be weight-sane, indicating that density information in items/resources/metals.json is not actually being used properly. Examples:

1. 1 liter of native copper produces 4.41 liters of copper. Described as scraps, implying some weight-inefficiency, but this seems illogical when a "scrap copper" item already exists.
2. 1 liter of native silver produces 3.5 liters of silver.
3. 1 liter of native gold produces 3.8 liters of gold.
4. 1 liter of galena produces 2.1 liters of lead. Expected volume at 82% yield-by-weight: 555.556 milliliters.

Related but less severe, 1 liter of cassiterite yields 1.6 liters of tin. Tin description implies scraps, so some volume inefficiency is expected, and less of a disparity as with copper.