### PR TITLE
Overmap Special Additions/Updates

### DIFF
--- a/Mining_Mod/construction.json
+++ b/Mining_Mod/construction.json
@@ -26,5 +26,17 @@
         ],
         "pre_terrain" : "f_boulder_large",
         "post_terrain" : "f_anvil_stone"
-    }
+    },
+  {
+    "type": "construction",
+    "id": "constr_extract_sand_black",
+    "description": "Extract Black Sand",
+    "category": "OTHER",
+    "required_skills": [ [ "survival", 0 ] ],
+    "time": "30 m",
+    "qualities": [ [ { "id": "DIG", "level": 1 } ] ],
+    "byproducts": [ { "item": "material_sand_black", "charges": [ 200, 400 ] } ],
+    "pre_terrain": "t_sand_black",
+    "post_special": "done_extract_maybe_revert_to_dirt"
+  }
 ]

--- a/Mining_Mod/items.json
+++ b/Mining_Mod/items.json
@@ -163,5 +163,22 @@
     "copy-from": "fake_item",
     "name": "leveled boulder anvil",
     "qualities": [ [ "ANVIL", 3 ] ]
+  },
+  {
+    "type": "AMMO",
+    "id": "material_sand_black",
+    "category": "spare_parts",
+    "price": 0,
+    "name": { "str": "black sand", "str_pl": "black sand" },
+    "symbol": "=",
+    "color": "dark_gray",
+    "description": "A handful of sand, rich with minerals eroded from a deposit somewhere upstream.  Not as useful in this state, but might be a source of magnetite.",
+    "material": "powder_nonflam",
+    "volume": "250 ml",
+    "//": "Roughly half magnetite, which has a density of 7.874 grams per cubic liter, and each unit is 5 mL.",
+    "weight": "23 g",
+    "bashing": 1,
+    "ammo_type": "components",
+    "count": 50
   }
 ]

--- a/Mining_Mod/mapgen_surface.json
+++ b/Mining_Mod/mapgen_surface.json
@@ -541,7 +541,7 @@
   "type" : "mapgen",
   "om_terrain" : ["swamp_hematite"],
   "method": "json",
-  "weight": 1000, "comment": "Suspisciously dry, dead patch of ground, with small hints of fragmenta.  Some chance of bog iron.",
+  "weight": 1000, "comment": "Suspiciously dry, dead patch of ground, with small hints of fragmenta.  Some chance of bog iron.",
   "object": {
    "rows": [
     "                        ",
@@ -598,6 +598,44 @@
           ]
         }
       }
+	}
+},
+{
+  "type" : "mapgen",
+  "om_terrain" : ["alluvial_deposit"],
+  "method": "json",
+  "weight": 1000, "//": "Ground is more barren and signs of water flow, leaving alluvial deposits in the form of black sand.",
+  "object": {
+   "rows": [
+    "                        ",
+    "                        ",
+    "                        ",
+    "                        ",
+    "                        ",
+    "                        ",
+    "                        ",
+    "                        ",
+    "          ....          ",
+    "         ......         ",
+    "        ........        ",
+    "        ........        ",
+    "        ........        ",
+    "        ........        ",
+    "         ......         ",
+    "          ....          ",
+    "                        ",
+    "                        ",
+    "                        ",
+    "                        ",
+    "                        ",
+    "                        ",
+    "                        ",
+    "                        "
+            ],
+   "terrain": {
+      " ": [ [ "t_region_groundcover_barren", 5 ], [ "t_region_groundcover", 3 ], [ "t_water_sh", 2 ], "t_sand" ],
+        ".": [ [ "t_region_groundcover_barren", 4 ], "t_sand" ]
+   }
 	}
 }
 ]

--- a/Mining_Mod/overmap_specials.json
+++ b/Mining_Mod/overmap_specials.json
@@ -8,10 +8,10 @@
         ],
         "locations" : [ "forest" ],
         "city_distance" : [5, -1],
-        "city_sizes" : [0, 12],
-        "occurrences" : [1, 10],
+        "city_sizes" : [0, 20],
+        "occurrences" : [0, 20],
         "rotate" : false,
-        "flags" : [ "CLASSIC" ]
+    "flags": [ "CLASSIC", "WILDERNESS" ]
     },
     {
         "type" : "overmap_special",
@@ -23,9 +23,9 @@
         "locations" : [ "wilderness" ],
         "city_distance" : [5, -1],
         "city_sizes" : [0, 12],
-        "occurrences" : [1, 10],
+        "occurrences" : [0, 20],
         "rotate" : false,
-        "flags" : [ "CLASSIC" ]
+    "flags": [ "CLASSIC", "WILDERNESS" ]
     },
     {
         "type" : "overmap_special",
@@ -37,9 +37,9 @@
         "locations" : [ "swamp" ],
         "city_distance" : [5, -1],
         "city_sizes" : [0, 12],
-        "occurrences" : [1, 10],
+        "occurrences" : [0, 20],
         "rotate" : false,
-        "flags" : [ "CLASSIC" ]
+    "flags": [ "CLASSIC", "WILDERNESS" ]
     },
     {
         "type" : "overmap_special",
@@ -55,9 +55,9 @@
         "locations" : [ "forest" ],
         "city_distance" : [5, -1],
         "city_sizes" : [0, 12],
-        "occurrences" : [1, 10],
+        "occurrences" : [0, 20],
         "rotate" : false,
-        "flags" : [ "CLASSIC" ]
+    "flags": [ "CLASSIC", "WILDERNESS" ]
     },
     {
         "type" : "overmap_special",
@@ -73,9 +73,9 @@
         "locations" : [ "wilderness" ],
         "city_distance" : [5, -1],
         "city_sizes" : [0, 12],
-        "occurrences" : [1, 10],
+        "occurrences" : [0, 20],
         "rotate" : false,
-        "flags" : [ "CLASSIC" ]
+    "flags": [ "CLASSIC", "WILDERNESS" ]
     },
     {
         "type" : "overmap_special",
@@ -91,8 +91,83 @@
         "locations" : [ "swamp" ],
         "city_distance" : [5, -1],
         "city_sizes" : [0, 12],
-        "occurrences" : [1, 10],
+        "occurrences" : [0, 20],
         "rotate" : false,
-        "flags" : [ "CLASSIC" ]
+    "flags": [ "CLASSIC", "WILDERNESS" ]
+    },
+  {
+    "type": "overmap_special",
+    "id": "Alluvial Deposit",
+    "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "alluvial_deposit_north" } ],
+        "locations" : [ "water", "swamp" ],
+    "occurrences": [ 0, 100 ],
+        "city_distance" : [5, -1],
+        "city_sizes" : [0, 20],
+    "flags": [ "CLASSIC", "WILDERNESS" ]
+  },
+    {
+        "type" : "overmap_special",
+        "id" : "vein_hidden_1",
+        "overmaps" : [
+            { "point":[0,0,-1], "overmap": "vein_rock"}
+        ],
+        "locations" : [ "land", "water" ],
+        "city_distance" : [5, -1],
+        "city_sizes" : [0, 20],
+        "occurrences" : [0, 50],
+        "rotate" : false,
+    "flags": [ "CLASSIC", "WILDERNESS" ]
+    },
+    {
+        "type" : "overmap_special",
+        "id" : "vein_hidden_2",
+        "overmaps" : [
+            { "point":[0,0,-2], "overmap": "vein_rock"}
+        ],
+        "locations" : [ "land", "water" ],
+        "city_distance" : [5, -1],
+        "city_sizes" : [0, 20],
+        "occurrences" : [0, 50],
+        "rotate" : false,
+    "flags": [ "CLASSIC", "WILDERNESS" ]
+    },
+    {
+        "type" : "overmap_special",
+        "id" : "vein_hidden_3",
+        "overmaps" : [
+            { "point":[0,0,-3], "overmap": "vein_rock"}
+        ],
+        "locations" : [ "land", "water" ],
+        "city_distance" : [5, -1],
+        "city_sizes" : [0, 20],
+        "occurrences" : [0, 50],
+        "rotate" : false,
+    "flags": [ "CLASSIC", "WILDERNESS" ]
+    },
+    {
+        "type" : "overmap_special",
+        "id" : "vein_hidden_4",
+        "overmaps" : [
+            { "point":[0,0,-4], "overmap": "vein_rock"}
+        ],
+        "locations" : [ "land", "water" ],
+        "city_distance" : [5, -1],
+        "city_sizes" : [0, 20],
+        "occurrences" : [0, 50],
+        "rotate" : false,
+    "flags": [ "CLASSIC", "WILDERNESS" ]
+    },
+    {
+        "type" : "overmap_special",
+        "id" : "vein_hidden_5",
+        "overmaps" : [
+            { "point":[0,0,-5], "overmap": "vein_rock"}
+        ],
+        "locations" : [ "land", "water" ],
+        "city_distance" : [5, -1],
+        "city_sizes" : [0, 20],
+        "occurrences" : [0, 50],
+        "rotate" : false,
+    "flags": [ "CLASSIC", "WILDERNESS" ]
     }
 ]

--- a/Mining_Mod/overmap_terrain.json
+++ b/Mining_Mod/overmap_terrain.json
@@ -33,7 +33,6 @@
         "color" : "brown",
         "see_cost" : 2,
         "extras" : "field",
-        "spawns" : { "group": "GROUP_FOREST", "population": [0, 1], "chance": 80 },
         "flags" : [ "NO_ROTATE" ]
     },{
         "type" : "overmap_terrain",
@@ -43,7 +42,6 @@
         "color" : "brown",
         "see_cost" : 2,
         "extras" : "field",
-        "spawns" : { "group": "GROUP_FOREST", "population": [0, 1], "chance": 80 },
         "flags" : [ "NO_ROTATE" ]
     },{
         "type" : "overmap_terrain",
@@ -53,7 +51,6 @@
         "color" : "green",
         "see_cost" : 3,
         "extras" : "field",
-        "spawns" : { "group": "GROUP_FOREST", "population": [0, 3], "chance": 80 },
         "flags" : [ "NO_ROTATE" ]
     },
     {
@@ -64,7 +61,6 @@
         "color" : "cyan",
         "see_cost" : 4,
         "extras" : "field",
-        "spawns" : { "group": "GROUP_SWAMP", "population": [1, 4], "chance": 100 },
         "flags" : [ "NO_ROTATE" ]
     },
     {
@@ -75,7 +71,14 @@
         "color" : "cyan",
         "see_cost" : 4,
         "extras" : "field",
-        "spawns" : { "group": "GROUP_SWAMP", "population": [1, 4], "chance": 100 },
         "flags" : [ "NO_ROTATE" ]
+    },{
+        "type" : "overmap_terrain",
+        "id" : "alluvial_deposit",
+        "name" : "alluvial deposit",
+        "sym" : ".",
+        "color" : "light_gray",
+        "see_cost" : 2,
+        "extras" : "field"
     }
 ]

--- a/Mining_Mod/recipes.json
+++ b/Mining_Mod/recipes.json
@@ -112,13 +112,13 @@
     "batch_time_factors": [ 90, 4 ],
     "autolearn": true,
     "book_learn": [ [ "textbook_armschina", 3 ], [ "textbook_fabrication", 3 ], [ "welding_book", 3 ] ],
-    "//": "Hematite has around 70% yield of iron, total yield here is just over 69% at 3500 grams of steel.  Estimated 2% carbon content has minimal effect on these numbers.",
+    "//": "Hematite has around 70% yield of iron, total yield here is just over 69% at 3500 grams of steel.  Estimated 2% carbon content has minimal effect on these numbers.  Magnetite has around 80% yield, but ironsand isn't pure magnetite.",
     "result_mult": 3,
     "byproducts": [ [ "steel_chunk", 2 ] ],
     "using": [ [ "forging_standard", 4 ] ],
     "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [
-      [ [ "chunk_hematite", 1 ] ],
+      [ [ "chunk_hematite", 1 ], [ "material_sand_black", 400 ] ],
       [ [ "material_shrd_limestone", 1 ], [ "material_limestone", 10 ] ],
       [ [ "charcoal", 10 ], [ "coal_lump", 10 ] ]
     ]

--- a/Mining_Mod/terrain.json
+++ b/Mining_Mod/terrain.json
@@ -207,5 +207,17 @@
       "ter_set": "t_rock_floor",
       "items": [ { "item": "rock", "count": [ 3, 7 ] }, { "item": "chunk_hematite", "count": [ 2, 4 ], "prob": 80 } ]
     }
+  },
+  {
+    "type": "terrain",
+    "id": "t_sand_black",
+    "looks_like": "t_sand",
+    "name": "black sand",
+    "description": "A patch of dark, heavy sand that could be quite useful, if it was extracted properly.",
+    "symbol": ".",
+    "color": "light_gray",
+    "move_cost": 3,
+    "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT" ],
+    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
   }
 ]


### PR DESCRIPTION
* Made the surface spawns non-mandatory but made them more likely to show up via better placement data.
* Added random hidden underground veins that don't have any connection to the outside.
* Added alluvial deposits near rivers, a potential source of...
* Black sand, an alternative to hematite in the iron making recipe. Can be dug up via construction menu.
* Couple misc updates to the overmap specials and terrain.

A linting PR is gonna be seriously needed, and will follow right after this.