### PR TITLE
Implement activity levels for recipes

### DIFF
--- a/Mining_Mod/recipes.json
+++ b/Mining_Mod/recipes.json
@@ -2,6 +2,7 @@
   {
     "result": "copper",
     "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
     "id_suffix": "native",
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_MATERIALS",
@@ -18,6 +19,7 @@
   {
     "result": "silver_small",
     "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
     "id_suffix": "native",
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_MATERIALS",
@@ -34,6 +36,7 @@
   {
     "result": "gold_small",
     "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
     "id_suffix": "native",
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_MATERIALS",
@@ -50,6 +53,7 @@
   {
     "result": "material_aluminium_ingot",
     "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
     "id_suffix": "native",
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_MATERIALS",
@@ -66,6 +70,7 @@
   {
     "result": "tin",
     "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
     "id_suffix": "smelt",
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_MATERIALS",
@@ -84,6 +89,7 @@
   {
     "result": "lead",
     "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
     "id_suffix": "smelt",
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_MATERIALS",
@@ -103,6 +109,7 @@
   {
     "result": "steel_lump",
     "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
     "id_suffix": "smelt",
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_MATERIALS",
@@ -126,6 +133,7 @@
   {
     "result": "pickaxe_copper",
     "type": "recipe",
+    "activity_level": "BRISK_EXERCISE",
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_TOOLS",
     "skill_used": "fabrication",
@@ -141,6 +149,7 @@
   {
     "result": "pickaxe_bone",
     "type": "recipe",
+    "activity_level": "MODERATE_EXERCISE",
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_TOOLS",
     "skill_used": "fabrication",


### PR DESCRIPTION
Simply adds varying activity levels, with most crucible work being on par with melting metal in ammo recipes (light), copper picks being brisk (as the toolset involved is closer to actual blacksmithing than most copper tools), and bone picks being the default of moderate.