### PR TITLE
Fix itemgroup load error

### DIFF
--- a/Mining_Mod/item_groups.json
+++ b/Mining_Mod/item_groups.json
@@ -12,6 +12,6 @@
   {
     "id": "museum_primitive",
     "type": "item_group",
-    "items": [ { "item": "pickaxe_bone", "prob": 10, "charges-min": 30, "charges-max": 60 }, [ "pickaxe_copper", 5 ] ]
+    "items": [ [ "pickaxe_bone", 10 ], [ "pickaxe_copper", 5 ] ]
   }
 ]


### PR DESCRIPTION
* Changed bone pickaxes to not spawn with variable charges, as nested container fuckery currently can't handle that, at least not the way it used to be defined for this item.