### PR TITLE
Ensure bone pickaxe can dig stairs

### DIFF
--- a/Mining_Mod/items.json
+++ b/Mining_Mod/items.json
@@ -137,8 +137,8 @@
     "material": [ "wood" ],
     "symbol": "/",
     "color": "white",
-    "initial_charges": 90,
-    "max_charges": 90,
+    "initial_charges": 200,
+    "max_charges": 200,
     "charges_per_use": 10,
     "use_action": "PICKAXE",
     "flags": [ "SPEAR", "FRAGILE", "DIG_TOOL" ]

--- a/Mining_Mod_BN/items.json
+++ b/Mining_Mod_BN/items.json
@@ -137,8 +137,8 @@
     "material": [ "wood" ],
     "symbol": "/",
     "color": "white",
-    "initial_charges": 90,
-    "max_charges": 90,
+    "initial_charges": 200,
+    "max_charges": 200,
     "charges_per_use": 10,
     "use_action": "PICKAXE",
     "flags": [ "SPEAR", "FRAGILE", "DIG_TOOL" ]


### PR DESCRIPTION
At some point the tool usage for mining up/down stairs got massively increased, so nudged the charges up enough to ensure it actually works. Also makes them last a bit longer than before, but eh.

Still need to puzzle out any potentially things needed for a 0.F Stable release to fix any experimental JSON changes. I'm not even finished doing that for my own mods, weh. @.@