### PR TITLE
Pending BN update: vanilla bog iron

### DIFF
--- a/Mining_Mod_BN/item_groups.json
+++ b/Mining_Mod_BN/item_groups.json
@@ -7,7 +7,7 @@
   {
     "id": "mine_storage",
     "type": "item_group",
-    "items": [ [ "chunk_hematite", 3 ], [ "chunk_galena", 2 ] ]
+    "items": [ [ "chunk_galena", 2 ] ]
   },
   {
     "id": "museum_primitive",

--- a/Mining_Mod_BN/items.json
+++ b/Mining_Mod_BN/items.json
@@ -90,21 +90,6 @@
     "bashing": 3
   },
   {
-    "type": "GENERIC",
-    "id": "chunk_hematite",
-    "category": "spare_parts",
-    "price": 250,
-    "name": { "str": "chunk of hematite", "str_pl": "chunks of hematite" },
-    "symbol": "*",
-    "color": "brown",
-    "description": "A large chunk of hematite, an ore of iron.  It only needs to be smelted into a usable form.",
-    "material": "stone",
-    "volume": "1 L",
-    "//": "One liter, roughly 5.04 grams per cubic centimeter.",
-    "weight": "5040 g",
-    "bashing": 2
-  },
-  {
     "id": "pickaxe_copper",
     "type": "TOOL",
     "name": { "str": "copper pickaxe" },
@@ -146,20 +131,5 @@
     "copy-from": "fake_item",
     "name": { "str": "leveled boulder anvil" },
     "qualities": [ [ "ANVIL", 3 ] ]
-  },
-  {
-    "type": "AMMO",
-    "id": "material_sand_black",
-    "category": "spare_parts",
-    "name": { "str_sp": "black sand" },
-    "symbol": "=",
-    "color": "dark_gray",
-    "description": "A handful of sand, rich with minerals eroded from a deposit somewhere upstream.  Not as useful in this state, but might be a source of magnetite.",
-    "material": "powder_nonflam",
-    "volume": "250 ml",
-    "//": "Roughly half magnetite, which has a density of 7.874 grams per cubic liter, and each unit is 5 mL.",
-    "weight": "23 g",
-    "ammo_type": "components",
-    "count": 50
   }
 ]

--- a/Mining_Mod_BN/mapgen_surface.json
+++ b/Mining_Mod_BN/mapgen_surface.json
@@ -1,17 +1,5 @@
 [
   {
-    "id": "minerals_swamp",
-    "type": "item_group",
-    "//": "Technically limonite develops as bog iron, not hematite.",
-    "items": [ [ "chunk_hematite", 10 ] ]
-  },
-  {
-    "id": "rubble_fake",
-    "type": "item_group",
-    "//": "Unable to both randomly placed rubble and ensure rocks spawn underneath.",
-    "items": [ { "item": "rock", "prob": 100, "count-min": 1, "count-max": 3 } ]
-  },
-  {
     "type": "mapgen",
     "om_terrain": [ "field_shallow" ],
     "method": "json",
@@ -110,8 +98,7 @@
       "furniture": {
         "#": [ "f_boulder_small", "f_boulder_medium", "f_boulder_large" ],
         "?": [ "f_boulder_small", "f_boulder_medium", "f_rubble_rock" ]
-      },
-      "mapping": { "?": { "items": { "item": "rubble_fake", "chance": 33 } } }
+      }
     }
   },
   {
@@ -209,8 +196,7 @@
         ".": "t_dirt",
         "%": "t_dirt"
       },
-      "furniture": { "%": [ "f_null", "f_rubble_rock" ] },
-      "mapping": { "%": { "items": { "item": "rubble_fake", "chance": 50 } } }
+      "furniture": { "%": [ "f_null", "f_rubble_rock" ] }
     }
   },
   {
@@ -309,8 +295,7 @@
         "#": "t_rock",
         "?": "t_dirt"
       },
-      "furniture": { "?": [ "f_boulder_small", "f_boulder_medium", "f_rubble_rock" ] },
-      "mapping": { "?": { "items": { "item": "rubble_fake", "chance": 33 } } }
+      "furniture": { "?": [ "f_boulder_small", "f_boulder_medium", "f_rubble_rock" ] }
     }
   },
   {
@@ -412,8 +397,7 @@
       "furniture": {
         "#": [ "f_boulder_small", "f_boulder_medium", "f_boulder_large" ],
         "?": [ "f_boulder_small", "f_boulder_medium", "f_rubble_rock" ]
-      },
-      "mapping": { "?": { "items": { "item": "rubble_fake", "chance": 33 } } }
+      }
     }
   },
   {
@@ -511,8 +495,7 @@
         ".": "t_dirt",
         "%": "t_dirt"
       },
-      "furniture": { "%": [ "f_null", "f_rubble_rock" ] },
-      "mapping": { "%": { "items": { "item": "rubble_fake", "chance": 50 } } }
+      "furniture": { "%": [ "f_null", "f_rubble_rock" ] }
     }
   },
   {
@@ -611,8 +594,7 @@
         "#": "t_rock",
         "?": "t_dirt"
       },
-      "furniture": { "?": [ "f_boulder_small", "f_boulder_medium", "f_rubble_rock" ] },
-      "mapping": { "?": { "items": { "item": "rubble_fake", "chance": 33 } } }
+      "furniture": { "?": [ "f_boulder_small", "f_boulder_medium", "f_rubble_rock" ] }
     }
   },
   {
@@ -717,8 +699,7 @@
       "furniture": {
         "#": [ "f_boulder_small", "f_boulder_medium", "f_boulder_large" ],
         "?": [ "f_boulder_small", "f_boulder_medium", "f_rubble_rock" ]
-      },
-      "mapping": { "?": { "items": { "item": "rubble_fake", "chance": 33 } } }
+      }
     }
   },
   {
@@ -813,8 +794,7 @@
         ],
         "%": "t_dirt"
       },
-      "furniture": { "%": [ "f_null", "f_rubble_rock" ] },
-      "mapping": { "%": { "items": { "item": "rubble_fake", "chance": 50 } } }
+      "furniture": { "%": [ "f_null", "f_rubble_rock" ] }
     }
   },
   {
@@ -946,8 +926,7 @@
           "f_rubble_rock"
         ],
         "%": [ "f_null", "f_rubble_rock" ]
-      },
-      "mapping": { ".": { "items": { "item": "rubble_fake", "chance": 3 } }, "%": { "items": { "item": "rubble_fake", "chance": 50 } } }
+      }
     }
   },
   {
@@ -983,146 +962,8 @@
         "                        ",
         "                        "
       ],
-      "terrain": {
-        " ": [
-          "t_water_sh",
-          "t_water_dp",
-          "t_grass",
-          "t_grass",
-          "t_grass",
-          "t_grass",
-          "t_grass",
-          "t_grass",
-          "t_swater_sh",
-          "t_swater_sh",
-          "t_swater_dp",
-          "t_grass",
-          "t_dirt",
-          "t_dirt",
-          "t_dirt",
-          "t_dirt",
-          "t_dirt",
-          "t_swater_sh",
-          "t_swater_dp",
-          "t_swater_sh",
-          "t_grass",
-          "t_dirt",
-          "t_dirt",
-          "t_dirt",
-          "t_dirt",
-          "t_dirt",
-          "t_grass",
-          "t_grass",
-          "t_grass",
-          "t_grass",
-          "t_dirt",
-          "t_dirt",
-          "t_dirt",
-          "t_dirt",
-          "t_dirt",
-          "t_grass",
-          "t_grass",
-          "t_grass",
-          "t_grass",
-          "t_dirt",
-          "t_dirt",
-          "t_dirt",
-          "t_dirt",
-          "t_dirt",
-          "t_grass",
-          "t_grass",
-          "t_grass",
-          "t_grass",
-          "t_dirt",
-          "t_dirt",
-          "t_dirt",
-          "t_dirt",
-          "t_dirt",
-          "t_dirt",
-          "t_dirt",
-          "t_underbrush"
-        ],
-        ".": "t_dirt",
-        "%": "t_dirt"
-      },
-      "furniture": {
-        ".": [
-          "f_null",
-          "f_null",
-          "f_null",
-          "f_null",
-          "f_null",
-          "f_null",
-          "f_null",
-          "f_null",
-          "f_null",
-          "f_null",
-          "f_null",
-          "f_null",
-          "f_null",
-          "f_null",
-          "f_null",
-          "f_null",
-          "f_null",
-          "f_null",
-          "f_null",
-          "f_null",
-          "f_null",
-          "f_null",
-          "f_null",
-          "f_null",
-          "f_null",
-          "f_null",
-          "f_null",
-          "f_null",
-          "f_null",
-          "f_rubble_rock"
-        ],
-        "%": [ "f_null", "f_rubble_rock" ]
-      },
-      "mapping": {
-        ".": { "items": [ { "item": "rubble_fake", "chance": 3 }, { "item": "minerals_swamp", "chance": 1 } ] },
-        "%": { "items": [ { "item": "rubble_fake", "chance": 50 }, { "item": "minerals_swamp", "chance": 20 } ] }
-      }
-    }
-  },
-  {
-    "type": "mapgen",
-    "om_terrain": [ "alluvial_deposit" ],
-    "method": "json",
-    "weight": 1000,
-    "//": "Ground is more barren and signs of water flow, leaving alluvial deposits in the form of black sand.",
-    "object": {
-      "rows": [
-        "                        ",
-        "                        ",
-        "                        ",
-        "                        ",
-        "                        ",
-        "                        ",
-        "                        ",
-        "                        ",
-        "          ....          ",
-        "         ......         ",
-        "        ........        ",
-        "        ........        ",
-        "        ........        ",
-        "        ........        ",
-        "         ......         ",
-        "          ....          ",
-        "                        ",
-        "                        ",
-        "                        ",
-        "                        ",
-        "                        ",
-        "                        ",
-        "                        ",
-        "                        "
-      ],
-      "terrain": {
-        " ": [ [ "t_region_groundcover", 15 ], [ "t_region_groundcover_barren", 10 ], [ "t_swater_sh", 5 ], "t_sand_black" ],
-        ".": [ [ "t_region_groundcover_barren", 4 ], "t_sand_black" ]
-      }
+      "terrain": { " ": "t_region_groundcover_swamp", ".": [ [ "t_region_groundcover_swamp", 9 ], "t_bog_iron" ], "%": "t_dirt" },
+      "furniture": { ".": [ [ "f_null", 29 ], "f_rubble_rock" ], "%": [ "f_null", "f_rubble_rock" ] }
     }
   }
 ]

--- a/Mining_Mod_BN/obsolete.json
+++ b/Mining_Mod_BN/obsolete.json
@@ -1,0 +1,102 @@
+[
+  {
+    "type": "GENERIC",
+    "id": "chunk_hematite",
+    "category": "spare_parts",
+    "price": 250,
+    "name": { "str": "chunk of hematite", "str_pl": "chunks of hematite" },
+    "symbol": "*",
+    "color": "brown",
+    "description": "A large chunk of hematite, an ore of iron.  It only needs to be smelted into a usable form.",
+    "material": "stone",
+    "volume": "1 L",
+    "//": "One liter, roughly 5.04 grams per cubic centimeter.",
+    "weight": "5040 g",
+    "bashing": 2
+  },
+  {
+    "type": "AMMO",
+    "id": "material_sand_black",
+    "category": "spare_parts",
+    "name": { "str_sp": "black sand" },
+    "symbol": "=",
+    "color": "dark_gray",
+    "description": "A handful of sand, rich with minerals eroded from a deposit somewhere upstream.  Not as useful in this state, but might be a source of magnetite.",
+    "material": "powder_nonflam",
+    "volume": "250 ml",
+    "//": "Roughly half magnetite, which has a density of 7.874 grams per cubic liter, and each unit is 5 mL.",
+    "weight": "23 g",
+    "ammo_type": "components",
+    "count": 50
+  },
+  {
+    "type": "terrain",
+    "id": "t_sand_black",
+    "looks_like": "t_sand",
+    "name": "black sand",
+    "description": "A patch of dark, heavy sand that seems to no longer be very useful.",
+    "symbol": ".",
+    "color": "light_gray",
+    "move_cost": 3,
+    "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT" ],
+    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+  },
+  {
+    "type": "overmap_terrain",
+    "id": "alluvial_deposit",
+    "name": "alluvial deposit",
+    "sym": ".",
+    "color": "light_gray",
+    "see_cost": 2,
+    "extras": "field"
+  },
+  {
+    "type": "overmap_special",
+    "id": "Alluvial Deposit",
+    "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "alluvial_deposit_north" } ],
+    "locations": [ "water", "swamp" ],
+    "occurrences": [ 0, 100 ],
+    "city_distance": [ 5, -1 ],
+    "city_sizes": [ 0, 0 ],
+    "flags": [ "CLASSIC", "WILDERNESS" ]
+  },
+  {
+    "type": "mapgen",
+    "om_terrain": [ "alluvial_deposit" ],
+    "method": "json",
+    "weight": 1000,
+    "//": "Ground is more barren and signs of water flow, leaving alluvial deposits in the form of black sand.",
+    "object": {
+      "rows": [
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "          ....          ",
+        "         ......         ",
+        "        ........        ",
+        "        ........        ",
+        "        ........        ",
+        "        ........        ",
+        "         ......         ",
+        "          ....          ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        "
+      ],
+      "terrain": {
+        " ": [ [ "t_region_groundcover", 15 ], [ "t_region_groundcover_barren", 10 ], [ "t_swater_sh", 5 ], "t_sand_black" ],
+        ".": [ [ "t_region_groundcover_barren", 4 ], "t_sand_black" ]
+      }
+    }
+  }
+]

--- a/Mining_Mod_BN/overmap_specials.json
+++ b/Mining_Mod_BN/overmap_specials.json
@@ -88,16 +88,6 @@
   },
   {
     "type": "overmap_special",
-    "id": "Alluvial Deposit",
-    "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "alluvial_deposit_north" } ],
-    "locations": [ "water", "swamp" ],
-    "occurrences": [ 0, 100 ],
-    "city_distance": [ 5, -1 ],
-    "city_sizes": [ 0, 20 ],
-    "flags": [ "CLASSIC", "WILDERNESS" ]
-  },
-  {
-    "type": "overmap_special",
     "id": "vein_hidden_1",
     "overmaps": [ { "point": [ 0, 0, -1 ], "overmap": "vein_rock" } ],
     "locations": [ "land", "water" ],

--- a/Mining_Mod_BN/overmap_terrain.json
+++ b/Mining_Mod_BN/overmap_terrain.json
@@ -75,14 +75,5 @@
     "see_cost": 4,
     "extras": "field",
     "flags": [ "NO_ROTATE" ]
-  },
-  {
-    "type": "overmap_terrain",
-    "id": "alluvial_deposit",
-    "name": "alluvial deposit",
-    "sym": ".",
-    "color": "light_gray",
-    "see_cost": 2,
-    "extras": "field"
   }
 ]

--- a/Mining_Mod_BN/recipes.json
+++ b/Mining_Mod_BN/recipes.json
@@ -101,29 +101,6 @@
     "components": [ [ [ "chunk_galena", 1 ] ] ]
   },
   {
-    "result": "steel_lump",
-    "type": "recipe",
-    "id_suffix": "smelt",
-    "category": "CC_OTHER",
-    "subcategory": "CSC_OTHER_MATERIALS",
-    "skill_used": "fabrication",
-    "difficulty": 4,
-    "time": "60 m",
-    "batch_time_factors": [ 90, 4 ],
-    "autolearn": true,
-    "book_learn": [ [ "textbook_armschina", 3 ], [ "textbook_fabrication", 3 ], [ "welding_book", 3 ] ],
-    "//": "Hematite has around 70% yield of iron, total yield here is just over 69% at 3500 grams of steel.  Estimated 2% carbon content has minimal effect on these numbers.  Magnetite has around 80% yield, but ironsand isn't pure magnetite.",
-    "result_mult": 3,
-    "byproducts": [ [ "steel_chunk", 2 ] ],
-    "using": [ [ "forging_standard", 4 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
-    "components": [
-      [ [ "chunk_hematite", 1 ], [ "material_sand_black", 400 ] ],
-      [ [ "material_shrd_limestone", 1 ], [ "material_limestone", 10 ] ],
-      [ [ "charcoal", 10 ], [ "coal_lump", 10 ] ]
-    ]
-  },
-  {
     "result": "pickaxe_copper",
     "type": "recipe",
     "category": "CC_OTHER",

--- a/Mining_Mod_BN/terrain.json
+++ b/Mining_Mod_BN/terrain.json
@@ -205,19 +205,7 @@
       "sound": "crash!",
       "sound_fail": "whump!",
       "ter_set": "t_rock_floor",
-      "items": [ { "item": "rock", "count": [ 3, 7 ] }, { "item": "chunk_hematite", "count": [ 2, 4 ], "prob": 80 } ]
+      "items": [ { "item": "rock", "count": [ 3, 7 ] }, { "item": "iron_ore", "count": [ 6, 12 ], "prob": 80 } ]
     }
-  },
-  {
-    "type": "terrain",
-    "id": "t_sand_black",
-    "looks_like": "t_sand",
-    "name": "black sand",
-    "description": "A patch of dark, heavy sand that could be quite useful, if it was extracted properly.",
-    "symbol": ".",
-    "color": "light_gray",
-    "move_cost": 3,
-    "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
   }
 ]


### PR DESCRIPTION
Some preparations for when/if https://github.com/cataclysmbnteam/Cataclysm-BN/pull/3506 is merged.

1. Obsoleted hematite and black sand items now that generic iron ore is set to be in mainline BN.
2. Set it so hematite veins yield generic iron ore when mined.
3. Removed alluvial deposits since swamps fill the role decently, especially combined with the still-existing bog iron special.
4. Speaking of, set it so bog iron location uses the new bog iron terrain at a higher spawn rate instead of spawning hematite items.
5. Deleted the crucible steel recipe outright since it's basically being mainlined with the same id_suffix plus some tweaks.
6. Belatedly phased out the fake rubble spawns used by surface indicators now that rubble in BN automatically generates its bash yield when cleaned up.